### PR TITLE
Display launch time in original timezone, Add Luxon

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "emotion-theming": "^10.0.27",
+    "luxon": "^2.3.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.8",

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,6 +19,7 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
@@ -114,6 +115,7 @@ function Header({ launch }) {
 }
 
 function TimeAndLocation({ launch }) {
+  const launchDateLocal = formatDateTime(launch.launch_date_local);
   return (
     <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
       <Stat>
@@ -124,7 +126,9 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip label={launchDateLocal} aria-label={launchDateLocal} placement="top">
+            {formatDateTime(launch.launch_date_local, true)}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",
@@ -7,8 +9,12 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
+export function formatDateTime(timestamp, keepTimeZone = false) {
+  const dateTime = DateTime.fromISO(timestamp, {
+    setZone: keepTimeZone,
+    locale: "en-US"
+  });
+  return dateTime.toLocaleString({
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -16,5 +22,5 @@ export function formatDateTime(timestamp) {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
-  }).format(new Date(timestamp));
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,6 +6621,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+luxon@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.3.1.tgz#f276b1b53fd9a740a60e666a541a7f6dbed4155a"
+  integrity sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
This fixes an issue where the launch date was displayed in the users local timezone. This PR changes that to instead display the date in the original timezone of the launch site as well as adding a tooltip which still shows the date in the users timezone.

The main problem seemed to be that `Intl.DateTimeFormat` does not accept offsets (eg. +08:00) in it's configuration, only a specific set of time zones (as stipulated in the [specification](https://tc39.es/ecma402/#sec-time-zone-names)) which are not provided by the SpaceX API.

Considerations:
- Deciding between Chakra's Tooltip and the `title` attribute (former favoured for UX)
- Whether to parse dates and perform manual string building (potentially unreliable) or use an external library (bundle size would increase)
- If all instances of using `Intl.DateTimeFormat` should change if an external library is used for this specific change

I decided to add Luxon (+20.43 KB) as it supports the options for `Intl.DateTimeFormat` and required minimal changes to the `formatDateTime` function.

Alternatives:
- In future the [Temporal API](https://github.com/tc39/proposal-temporal) may be helpful 

